### PR TITLE
distcheck2: remove bzip2 archive generation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,11 +38,8 @@ EXTRA_DIST = \
 
 DISTCHECK_CONFIGURE_FLAGS = --enable-htmldoc
 
-dist2: dist
-	gzip -dc $(distdir).tar.gz | bzip2 -9 >$(distdir).tar.bz2
-
-distcheck2: distcheck dist2
-	@banner="$(distdir).tar.bz2 - ready for distribution"; \
+distcheck2: distcheck
+	@banner="$(distdir).tar.gz - ready for distribution"; \
 	dashes=`echo "$$banner" | sed s/./=/g`; \
 	echo "$$banner"; \
 	echo "$$dashes"


### PR DESCRIPTION
Having two sets of generated archives was always wasteful, and the release
mechanism on Github only allows for zip or tar.gz to be uploaded, making the
bzip2 archive redundant.