### PR TITLE
Rework release-gen to use git tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get -y install debhelper autotools-dev dh-autoreconf file fontconfig gettext libfontconfig-dev libfreetype6-dev libfribidi-dev libncurses5-dev libreadline-dev libpng-dev libsm-dev libx11-dev libxcursor-dev libxext-dev libxft-dev libxi-dev x11proto-xinerama-dev libxpm-dev libxrender-dev libxt-dev sharutils xsltproc build-essential
-script: (CFLAGS= ./autogen.sh) && make && make distcheck2
+script: (CFLAGS= ./autogen.sh) && make
 notifications:
         irc:
                 channels:

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,7 @@ distcheck2: distcheck
 	@if test "x$(ISRELEASED)" != xyes; then \
 		echo 'Warning: ISRELEASED is not set to "yes".'; \
 		echo '	So these can not be the official tarballs.'; \
+		exit 1; \
 	fi
 
 distclean2: distclean

--- a/autogen.sh
+++ b/autogen.sh
@@ -6,5 +6,5 @@ die()
     exit $2
 }
 
-autoreconf -f -i -v -m || die "autoreconf failed" $? && \
-	./configure
+autoreconf -f -i -v || die "autoreconf failed" $?
+./configure || die "configure failed" $?

--- a/configure.ac
+++ b/configure.ac
@@ -3,8 +3,18 @@ dnl
 AC_PREREQ(2.60)
 
 dnl should be "yes" only within the released distribution
-ISRELEASED=no
-AC_INIT([fvwm], 2.6.7)
+ISRELEASED="no"
+if test $ISRELEASED = "no"; then
+	RELDATELONG=""
+	RELDATESHORT=""
+	RELDATENUM=""
+fi
+
+AC_INIT([fvwm],
+	m4_esyscmd_s([utils/fvwm-version-str.sh]),
+	[fvwm-workers@fvwm.org])
+AM_INIT_AUTOMAKE([foreign])
+AM_CONFIG_HEADER(config.h)
 
 VERSIONINFO=""
 
@@ -27,29 +37,6 @@ FVWMWORKERSLIST="fvwm-workers@fvwm.org"
 FVWMWORKERSLISTLONG="fvwm workers list <fvwm-workers@fvwm.org>"
 MANPAGE_PREAMBLE='.\" WARNING: This file was automatically generated.  Edit the .in file instead.'
 
-if test ! x"$ISRELEASED" = xyes; then
-	VERSIONINFO=" (from cvs)"
-	RELDATELONG="(not released yet)"
-	RELDATESHORT="(not released yet)"
-	RELDATENUM="(not released yet)"
-#	# migo: unfortunately this nice idea can not work, it is not updated.
-#	# I will think more about this, maybe autoconf-2.50+ has a solution.
-#	if test -d CVS/ -a -f CVS/Entries && \
-#		date +%Y-%m-%d -d 'Wed Sep  4 12:36:50 2002' >/dev/null 2>&1
-#	then
-#		# this is not the exact date, but better than the current date
-#		for file in CVS/Entries */CVS/Entries; do
-#			changelog_date="`cat $file | grep /ChangeLog/ \
-#				| cut -d/ -f4`"
-#			test ! x"$changelog_date" = x && \
-#			date +%Y-%m-%d -d "$changelog_date" >>changelog_dates
-#		done
-#		changelog_date=`cat changelog_dates | sort -r -u | head -1`
-#		VERSIONINFO=" (from cvs $changelog_date)"
-#		rm -f changelog_dates
-#	fi
-fi
-
 AC_SUBST(ISRELEASED)
 AH_TEMPLATE([VERSIONINFO],[Additional version information, like date])
 AC_DEFINE_UNQUOTED(VERSIONINFO, "$VERSIONINFO")
@@ -67,9 +54,6 @@ AC_SUBST(FVWMLIST)
 AC_SUBST(FVWMWORKERSLIST)
 AC_SUBST(FVWMWORKERSLISTLONG)
 AC_SUBST(MANPAGE_PREAMBLE)
-
-AM_INIT_AUTOMAKE([foreign])
-AM_CONFIG_HEADER(config.h)
 
 # check for programs needed to build html docs
 AC_CHECK_PROG(SED, sed, sed, "")

--- a/docs/DEVELOPERS.md
+++ b/docs/DEVELOPERS.md
@@ -150,12 +150,17 @@ development that's happening which might impact a potential release.
 
 Make sure you have all optional libraries installed.
 
-0. `git checkout master && git pull` 
+**NOTE:  as `master` is a protected branch, changes made to files during the
+release phase must be done on a separate branch, and not on master directly,
+as pushes to this branch are not allowed until checks have been done on it.
+This means the end result of the release-phase must have these changes issued
+as a pull-request against `master`.**
+
+0. `git checkout master && git pull && git checkout -b release/x.y.z`
+   **Where: `x.y.z` will be the next release**.
 1. Change the dates in configure.ac and fill in the release dates.
-2. Verify that the version variable at the very beginning of
-   configure.ac has the value of the going to be released version
-   and set `ISRELEASED` to `yes`.
-3. Commit the results:  `git commit -a`
+2. Set `ISRELEASED` to `"yes"`.
+3. Commit the results.
 4. Run: `./autogen.sh && make clean` to get the tree into a clean
    slate.  Because this is a release, the source needs compiling.  To do
    that, run:
@@ -166,7 +171,9 @@ Make sure you have all optional libraries installed.
 
     Fix all warnings and problems, commit the changes and repeat the previous
     command until no more warnings occur.
-5. Build and test the release tarballs:
+5. Tag the release: `git tag -a x.y.z` -- where `x.y.z` represents the
+   appropriate version number for the release.
+6. Build and test the release tarballs:
 
    Run: `make distcheck2`
 
@@ -174,11 +181,13 @@ Make sure you have all optional libraries installed.
    directory.  This is the release tarball which will be uploaded to Github.
    Unpack it to a temporary directory and build it; check the version as well,
    via: `./fvwm --version`.
-6. Tag the release: `git tag -a` 
-7. Push the tag out: `git push --tags`
-8. Upload the `fvwm-x.y.z.tar.gz` tarball to Github.
-9. Increase the version number in `configure.ac` and set `ISRELEASED` to `no`
-10. Commit that, and push it out.
+7. Push the tag out: `git push origin x.y.z` -- where `x.y.z` is the specific
+   tag created in step 5.
+8. Set `ISRELEASED` to `"no"` in configure.ac and commit and push that out.
+9. Issue a PR (pull-request) against `master` and mege that in assuming all
+    checks pass.  If not, fix the problems, and repeat this step.
+10. Upload the `fvwm-x.y.z.tar.gz` tarball to Github against the tag just
+   pushed.
 
 Updating fvwm-web
 =================

--- a/docs/DEVELOPERS.md
+++ b/docs/DEVELOPERS.md
@@ -1,3 +1,5 @@
+<!--- IF THIS DOCUMENT IS UPDATED THEN ALSO UPDATE THE FVWM WEB REPO --->
+
 Developing for FVWM
 ===================
 

--- a/utils/fvwm-version-str.sh
+++ b/utils/fvwm-version-str.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# fvwm-version-str: emits the version of fvwm which is building.
+#		    If this is a release build, then the tag name is chomped
+#		    to remove extraneous git information.
+#
+#		    If it's a developer build, it's left as-is.
+#
+#
+#
+# Intended to be called from configure.ac (via autogen.sh)
+
+if grep -q -i '^ISRELEASED="yes"' ./configure.ac; then
+	# A release build.  Strip the git information off the tag name.
+	git describe --tags --abbrev=0
+else
+	git describe --always --long --dirty
+fi


### PR DESCRIPTION
This reworks how fvwm detects which version it's building, including propagating the version from the Git repository where available.