### PR TITLE
Unroll EWMH_CMD_ARGS macro

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1224,18 +1224,21 @@ void EWMH_SetFrameStrut(FvwmWindow *fw)
 /*
  * allowed actions
  */
-Bool ewmh_AllowsYes(EWMH_CMD_ARGS)
+Bool ewmh_AllowsYes(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	return True;
 }
 
-Bool ewmh_AllowsClose(EWMH_CMD_ARGS)
+Bool ewmh_AllowsClose(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	return is_function_allowed(
 		F_CLOSE, NULL, fw, RQORIG_PROGRAM_US, False);
 }
 
-Bool ewmh_AllowsFullScreen(EWMH_CMD_ARGS)
+Bool ewmh_AllowsFullScreen(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (
 		!is_function_allowed(
@@ -1251,22 +1254,26 @@ Bool ewmh_AllowsFullScreen(EWMH_CMD_ARGS)
 	return True;
 }
 
-Bool ewmh_AllowsMinimize(EWMH_CMD_ARGS)
+Bool ewmh_AllowsMinimize(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	return is_function_allowed(F_ICONIFY, NULL, fw, RQORIG_PROGRAM_US, False);
 }
 
-Bool ewmh_AllowsMaximize(EWMH_CMD_ARGS)
+Bool ewmh_AllowsMaximize(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	return is_function_allowed(F_MAXIMIZE, NULL, fw, RQORIG_PROGRAM_US, False);
 }
 
-Bool ewmh_AllowsMove(EWMH_CMD_ARGS)
+Bool ewmh_AllowsMove(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	return is_function_allowed(F_MOVE, NULL, fw, RQORIG_PROGRAM_US, False);
 }
 
-Bool ewmh_AllowsResize(EWMH_CMD_ARGS)
+Bool ewmh_AllowsResize(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	return is_function_allowed(F_RESIZE, NULL, fw, RQORIG_PROGRAM_US, False);
 }
@@ -1305,7 +1312,8 @@ void EWMH_SetAllowedActions(FvwmWindow *fw)
  * Window types
  */
 
-int ewmh_HandleDesktop(EWMH_CMD_ARGS)
+int ewmh_HandleDesktop(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (Scr.EwmhDesktop != NULL && FW_W(Scr.EwmhDesktop) != FW_W(fw))
 	{
@@ -1400,14 +1408,16 @@ int ewmh_HandleDesktop(EWMH_CMD_ARGS)
 	return 1;
 }
 
-int ewmh_HandleDialog(EWMH_CMD_ARGS)
+int ewmh_HandleDialog(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	fw->ewmh_window_type = EWMH_WINDOW_TYPE_DIALOG_ID;
 
 	return 0;
 }
 
-int ewmh_HandleDock(EWMH_CMD_ARGS)
+int ewmh_HandleDock(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	fw->ewmh_window_type = EWMH_WINDOW_TYPE_DOCK_ID;
 
@@ -1457,7 +1467,8 @@ int ewmh_HandleDock(EWMH_CMD_ARGS)
 	return 1;
 }
 
-int ewmh_HandleMenu(EWMH_CMD_ARGS)
+int ewmh_HandleMenu(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	fw->ewmh_window_type = EWMH_WINDOW_TYPE_MENU_ID;
 
@@ -1499,14 +1510,16 @@ int ewmh_HandleMenu(EWMH_CMD_ARGS)
 	return 1;
 }
 
-int ewmh_HandleNormal(EWMH_CMD_ARGS)
+int ewmh_HandleNormal(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	fw->ewmh_window_type = EWMH_WINDOW_TYPE_NORMAL_ID;
 
 	return 0;
 }
 
-int ewmh_HandleToolBar(EWMH_CMD_ARGS)
+int ewmh_HandleToolBar(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	fw->ewmh_window_type = EWMH_WINDOW_TYPE_TOOLBAR_ID;
 
@@ -1532,7 +1545,8 @@ int ewmh_HandleToolBar(EWMH_CMD_ARGS)
 	return 1;
 }
 
-int ewmh_HandleNotification(EWMH_CMD_ARGS)
+int ewmh_HandleNotification(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	/* fw->ewmh_window_type is generally used by FvwmIdent, but for this
 	 * EWMH type it is not used.  Reporting on unmanaged windows with

--- a/fvwm/ewmh_events.c
+++ b/fvwm/ewmh_events.c
@@ -49,7 +49,8 @@ extern ewmh_atom ewmh_atom_wm_state[];
 /*
  * root
  */
-int ewmh_CurrentDesktop(EWMH_CMD_ARGS)
+int ewmh_CurrentDesktop(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev->xclient.data.l[0] < 0 || ev->xclient.data.l[0] > 0x7fffffff)
 	{
@@ -70,7 +71,8 @@ int ewmh_CurrentDesktop(EWMH_CMD_ARGS)
 	return -1;
 }
 
-int ewmh_DesktopGeometry(EWMH_CMD_ARGS)
+int ewmh_DesktopGeometry(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	char action[256];
 	long width = ev->xclient.data.l[0];
@@ -100,7 +102,8 @@ int ewmh_DesktopGeometry(EWMH_CMD_ARGS)
 	return -1;
 }
 
-int ewmh_DesktopViewPort(EWMH_CMD_ARGS)
+int ewmh_DesktopViewPort(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (
 		ev->xclient.data.l[0] < 0 ||
@@ -125,7 +128,8 @@ int ewmh_DesktopViewPort(EWMH_CMD_ARGS)
 	return -1;
 }
 
-int ewmh_NumberOfDesktops(EWMH_CMD_ARGS)
+int ewmh_NumberOfDesktops(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	int d = ev->xclient.data.l[0];
 
@@ -156,7 +160,8 @@ int ewmh_NumberOfDesktops(EWMH_CMD_ARGS)
  * window
  */
 
-int ewmh_ActiveWindow(EWMH_CMD_ARGS)
+int ewmh_ActiveWindow(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev == NULL)
 	{
@@ -168,7 +173,8 @@ int ewmh_ActiveWindow(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_CloseWindow(EWMH_CMD_ARGS)
+int ewmh_CloseWindow(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev == NULL)
 	{
@@ -183,7 +189,8 @@ int ewmh_CloseWindow(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_MoveResizeWindow(EWMH_CMD_ARGS)
+int ewmh_MoveResizeWindow(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	int do_reconfigure;
 	int win_gravity;
@@ -236,7 +243,8 @@ int ewmh_MoveResizeWindow(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_RestackWindow(EWMH_CMD_ARGS)
+int ewmh_RestackWindow(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	int do_restack;
 
@@ -268,7 +276,8 @@ int ewmh_RestackWindow(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMDesktop(EWMH_CMD_ARGS)
+int ewmh_WMDesktop(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev != NULL && style == NULL)
 	{
@@ -370,7 +379,8 @@ int ewmh_WMDesktop(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_MoveResize(EWMH_CMD_ARGS)
+int ewmh_MoveResize(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	int dir = -1;
 	int x_warp = 0;
@@ -460,7 +470,8 @@ int ewmh_MoveResize(EWMH_CMD_ARGS)
 /*
  * WM_STATE*
  */
-int ewmh_WMState(EWMH_CMD_ARGS)
+int ewmh_WMState(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	unsigned long maximize = 0;
 
@@ -554,7 +565,8 @@ int ewmh_WMState(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateFullScreen(EWMH_CMD_ARGS)
+int ewmh_WMStateFullScreen(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev == NULL && style == NULL)
 	{
@@ -635,7 +647,8 @@ int ewmh_WMStateFullScreen(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateHidden(EWMH_CMD_ARGS)
+int ewmh_WMStateHidden(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev == NULL && style == NULL)
 	{
@@ -714,7 +727,8 @@ int ewmh_WMStateHidden(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateMaxHoriz(EWMH_CMD_ARGS)
+int ewmh_WMStateMaxHoriz(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 
 	if (ev == NULL && style == NULL)
@@ -789,7 +803,8 @@ int ewmh_WMStateMaxHoriz(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateMaxVert(EWMH_CMD_ARGS)
+int ewmh_WMStateMaxVert(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 
 	if (ev == NULL && style == NULL)
@@ -859,7 +874,8 @@ int ewmh_WMStateMaxVert(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateModal(EWMH_CMD_ARGS)
+int ewmh_WMStateModal(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev == NULL && style == NULL)
 	{
@@ -965,7 +981,8 @@ int ewmh_WMStateModal(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateShaded(EWMH_CMD_ARGS)
+int ewmh_WMStateShaded(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 
 	if (ev == NULL && style == NULL)
@@ -1044,7 +1061,8 @@ int ewmh_WMStateShaded(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateSkipPager(EWMH_CMD_ARGS)
+int ewmh_WMStateSkipPager(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev == NULL && style == NULL)
 	{
@@ -1114,7 +1132,8 @@ int ewmh_WMStateSkipPager(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateSkipTaskBar(EWMH_CMD_ARGS)
+int ewmh_WMStateSkipTaskBar(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev == NULL && style == NULL)
 	{
@@ -1185,7 +1204,8 @@ int ewmh_WMStateSkipTaskBar(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateStaysOnTop(EWMH_CMD_ARGS)
+int ewmh_WMStateStaysOnTop(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev == NULL && style == NULL)
 	{
@@ -1272,7 +1292,8 @@ int ewmh_WMStateStaysOnTop(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateStaysOnBottom(EWMH_CMD_ARGS)
+int ewmh_WMStateStaysOnBottom(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	if (ev == NULL && style == NULL)
 	{
@@ -1358,7 +1379,8 @@ int ewmh_WMStateStaysOnBottom(EWMH_CMD_ARGS)
 	return 0;
 }
 
-int ewmh_WMStateSticky(EWMH_CMD_ARGS)
+int ewmh_WMStateSticky(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 
 	if (ev == NULL && style == NULL)
@@ -1443,7 +1465,8 @@ int ewmh_WMStateSticky(EWMH_CMD_ARGS)
  * Property Notify (_NET_WM_ICON is in ewmh_icon.c, _NET_WM_*NAME are in
  * ewmh_name)                        *
  */
-int ewmh_WMIconGeometry(EWMH_CMD_ARGS)
+int ewmh_WMIconGeometry(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	int size;
 	CARD32 *val;
@@ -1506,7 +1529,8 @@ void EWMH_GetIconGeometry(FvwmWindow *fw, rectangle *icon_rect)
 	return;
 }
 
-int ewmh_WMStrut(EWMH_CMD_ARGS)
+int ewmh_WMStrut(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	int size = 0;
 	CARD32 *val;

--- a/fvwm/ewmh_icons.c
+++ b/fvwm/ewmh_icons.c
@@ -44,7 +44,8 @@
 /*
  * net icon handler
  */
-int ewmh_WMIcon(EWMH_CMD_ARGS)
+int ewmh_WMIcon(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	CARD32 *list = NULL;
 	CARD32 *new_list = NULL;

--- a/fvwm/ewmh_intern.h
+++ b/fvwm/ewmh_intern.h
@@ -13,16 +13,13 @@
 #include "ftime.h"
 #endif
 
-#define EWMH_CMD_ARGS FvwmWindow *fw, XEvent *ev, window_style *style, \
-	unsigned long any
-
 typedef struct ewmh_atom
 {
 	char *name;
 	Atom atom;
 	Atom atom_type;
 #ifdef __STDC__
-	int (*action)(EWMH_CMD_ARGS);
+	int (*action)(FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 #else
 	int (*action)();
 #endif
@@ -96,13 +93,20 @@ void *ewmh_AtomGetByName(
 	Window win, const char *atom_name, ewmh_atom_list_name list,
 	int *size);
 
-int ewmh_HandleDesktop(EWMH_CMD_ARGS);
-int ewmh_HandleDialog(EWMH_CMD_ARGS);
-int ewmh_HandleDock(EWMH_CMD_ARGS);
-int ewmh_HandleMenu(EWMH_CMD_ARGS);
-int ewmh_HandleNormal(EWMH_CMD_ARGS);
-int ewmh_HandleToolBar(EWMH_CMD_ARGS);
-int ewmh_HandleNotification(EWMH_CMD_ARGS);
+int ewmh_HandleDesktop(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_HandleDialog(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_HandleDock(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_HandleMenu(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_HandleNormal(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_HandleToolBar(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_HandleNotification(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 
 void ewmh_AddToKdeSysTray(FvwmWindow *fw);
 void ewmh_SetWorkArea(void);
@@ -110,44 +114,75 @@ void ewmh_ComputeAndSetWorkArea(void);
 void ewmh_HandleDynamicWorkArea(void);
 void ewmh_HandleWindowType(FvwmWindow *fw, window_style *style);
 
-int ewmh_CurrentDesktop(EWMH_CMD_ARGS);
-int ewmh_DesktopGeometry(EWMH_CMD_ARGS);
-int ewmh_DesktopViewPort(EWMH_CMD_ARGS);
-int ewmh_NumberOfDesktops(EWMH_CMD_ARGS);
+int ewmh_CurrentDesktop(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_DesktopGeometry(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_DesktopViewPort(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_NumberOfDesktops(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 
-int ewmh_ActiveWindow(EWMH_CMD_ARGS);
-int ewmh_CloseWindow(EWMH_CMD_ARGS);
-int ewmh_MoveResizeWindow(EWMH_CMD_ARGS);
-int ewmh_RestackWindow(EWMH_CMD_ARGS);
-int ewmh_WMDesktop(EWMH_CMD_ARGS);
-int ewmh_MoveResize(EWMH_CMD_ARGS);
+int ewmh_ActiveWindow(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_CloseWindow(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_MoveResizeWindow(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_RestackWindow(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMDesktop(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_MoveResize(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 
-int ewmh_WMState(EWMH_CMD_ARGS);
-int ewmh_WMStateFullScreen(EWMH_CMD_ARGS);
-int ewmh_WMStateHidden(EWMH_CMD_ARGS);
-int ewmh_WMStateMaxHoriz(EWMH_CMD_ARGS);
-int ewmh_WMStateMaxVert(EWMH_CMD_ARGS);
-int ewmh_WMStateModal(EWMH_CMD_ARGS);
-int ewmh_WMStateShaded(EWMH_CMD_ARGS);
-int ewmh_WMStateSkipPager(EWMH_CMD_ARGS);
-int ewmh_WMStateSkipTaskBar(EWMH_CMD_ARGS);
-int ewmh_WMStateStaysOnTop(EWMH_CMD_ARGS);
-int ewmh_WMStateStaysOnBottom(EWMH_CMD_ARGS);
-int ewmh_WMStateSticky(EWMH_CMD_ARGS);
+int ewmh_WMState(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateFullScreen(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateHidden(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateMaxHoriz(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateMaxVert(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateModal(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateShaded(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateSkipPager(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateSkipTaskBar(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateStaysOnTop(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateStaysOnBottom(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStateSticky(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 
-int ewmh_WMIconGeometry(EWMH_CMD_ARGS);
-int ewmh_WMStrut(EWMH_CMD_ARGS);
+int ewmh_WMIconGeometry(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMStrut(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 
-Bool ewmh_AllowsYes(EWMH_CMD_ARGS);
-Bool ewmh_AllowsClose(EWMH_CMD_ARGS);
-Bool ewmh_AllowsFullScreen(EWMH_CMD_ARGS);
-Bool ewmh_AllowsMinimize(EWMH_CMD_ARGS);
-Bool ewmh_AllowsMaximize(EWMH_CMD_ARGS);
-Bool ewmh_AllowsMove(EWMH_CMD_ARGS);
-Bool ewmh_AllowsResize(EWMH_CMD_ARGS);
+Bool ewmh_AllowsYes(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+Bool ewmh_AllowsClose(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+Bool ewmh_AllowsFullScreen(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+Bool ewmh_AllowsMinimize(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+Bool ewmh_AllowsMaximize(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+Bool ewmh_AllowsMove(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+Bool ewmh_AllowsResize(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 
 /* ewmh_icon */
-int ewmh_WMIcon(EWMH_CMD_ARGS);
+int ewmh_WMIcon(FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 CARD32 *ewmh_SetWmIconFromPixmap(
 	FvwmWindow *fw, CARD32 *orig_icon, int *orig_size,
 	Bool is_mini_icon);

--- a/fvwm/ewmh_intern.h
+++ b/fvwm/ewmh_intern.h
@@ -182,7 +182,8 @@ Bool ewmh_AllowsResize(
 	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 
 /* ewmh_icon */
-int ewmh_WMIcon(FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMIcon(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 CARD32 *ewmh_SetWmIconFromPixmap(
 	FvwmWindow *fw, CARD32 *orig_icon, int *orig_size,
 	Bool is_mini_icon);

--- a/fvwm/ewmh_names.c
+++ b/fvwm/ewmh_names.c
@@ -123,7 +123,8 @@ void EWMH_SetVisibleName(FvwmWindow *fw, Bool is_icon_name)
 /*
  * setup and property notify
  */
-int EWMH_WMIconName(EWMH_CMD_ARGS)
+int EWMH_WMIconName(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	int size = 0;
 	char *val;
@@ -192,7 +193,8 @@ int EWMH_WMIconName(EWMH_CMD_ARGS)
 	return 1;
 }
 
-int EWMH_WMName(EWMH_CMD_ARGS)
+int EWMH_WMName(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
 {
 	int size = 0;
 	char *val;


### PR DESCRIPTION
Removed EWMH_CMD_ARGS macro and explicitly defined those arguments in
the prototypes and implementations. This clarifies the function's
purpose and ensures any future changes are more readily visible.