### PR TITLE
Dl8dtl/net wm fullscreen monitors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,7 +8,7 @@ Changes in stable release 2.6.8 (UNRELEASED)
 
   - Implementation of _NET_WM_FULLSCREEN_MONITORS EWMH feature, as
     used e.g. by VirtualBox and VMware Player for Xinerama setups
-    using multiple monitors
+    using multiple monitors.
 
 * Bug fixes:
 

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,12 @@ Note, the changes for the last STABLE release start with release
 -------------------------------------------------------------------
 Changes in stable release 2.6.8 (UNRELEASED)
 
+* New fvwm features:
+
+  - Implementation of _NET_WM_FULLSCREEN_MONITORS EWMH feature, as
+    used e.g. by VirtualBox and VMware Player for Xinerama setups
+    using multiple monitors
+
 * Bug fixes:
 
   - Various DESTDIR fixes (especially around the default-config

--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@ Changes in stable release 2.6.8 (UNRELEASED)
 * New fvwm features:
 
   - Implementation of _NET_WM_FULLSCREEN_MONITORS EWMH feature, as
-    used e.g. by VirtualBox and VMware Player for Xinerama setups
+    used e.g. by VirtualBox and VMware Workstation for Xinerama setups
     using multiple monitors.
 
 * Bug fixes:

--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -126,6 +126,7 @@ ewmh_atom ewmh_atom_client_win[] =
 	ENTRY("_NET_MOVERESIZE_WINDOW", XA_WINDOW,   ewmh_MoveResizeWindow),
 	ENTRY("_NET_RESTACK_WINDOW",    XA_WINDOW,   ewmh_RestackWindow),
 	ENTRY("_NET_WM_DESKTOP",        XA_CARDINAL, ewmh_WMDesktop),
+	ENTRY("_NET_WM_FULLSCREEN_MONITORS", XA_CARDINAL, ewmh_WMFullscreenMonitors),
 	ENTRY("_NET_WM_MOVERESIZE",     XA_WINDOW,   ewmh_MoveResize),
 	ENTRY("_NET_WM_STATE",          XA_ATOM,     ewmh_WMState),
 	{NULL,0,0,0}

--- a/fvwm/ewmh_events.c
+++ b/fvwm/ewmh_events.c
@@ -467,6 +467,60 @@ int ewmh_MoveResize(
 	return 0;
 }
 
+int ewmh_WMFullscreenMonitors(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any)
+{
+	int top, bottom, left, right, num_screens;
+	Bool had_fsmonitors_set = fw->fullscreen_monitors_set;
+
+	if (ev == NULL)
+	{
+		return 0;
+	}
+
+	if ((num_screens = FScreenNumberOfScreens()) == 0)
+	{
+		/* no Xinerama (or disabled) */
+		return 0;
+	}
+
+	fw->fullscreen_monitors_set = False;
+
+	top = (int)ev->xclient.data.l[0];
+	bottom = (int)ev->xclient.data.l[1];
+	left = (int)ev->xclient.data.l[2];
+	right = (int)ev->xclient.data.l[3];
+	if (top < num_screens ||
+	    bottom < num_screens ||
+	    left < num_screens ||
+	    right < num_screens)
+	{
+		fw->fullscreen_monitors_set = True;
+	}
+
+	if (fw->fullscreen_monitors_set)
+	{
+		long data[4];
+		data[0] = top;
+		data[1] = bottom;
+		data[2] = left;
+		data[3] = right;
+
+		ewmh_ChangeProperty(FW_W(fw),
+			"_NET_WM_FULLSCREEN_MONITORS",
+			EWMH_ATOM_LIST_CLIENT_WIN,
+			(unsigned char *)data, 4);
+	}
+	else if (had_fsmonitors_set)
+	{
+		ewmh_DeleteProperty(FW_W(fw),
+			"_NET_WM_FULLSCREEN_MONITORS",
+			EWMH_ATOM_LIST_CLIENT_WIN);
+	}
+
+	return 0;
+}
+
 /*
  * WM_STATE*
  */

--- a/fvwm/ewmh_intern.h
+++ b/fvwm/ewmh_intern.h
@@ -133,6 +133,8 @@ int ewmh_RestackWindow(
 	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 int ewmh_WMDesktop(
 	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
+int ewmh_WMFullscreenMonitors(
+	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 int ewmh_MoveResize(
 	FvwmWindow *fw, XEvent *ev, window_style *style, unsigned long any);
 

--- a/fvwm/fvwm.h
+++ b/fvwm/fvwm.h
@@ -970,6 +970,7 @@ typedef struct FvwmWindow
 	int ewmh_normal_layer; /* for restoring non ewmh layer */
 	/* memory for the initial _NET_WM_STATE */
 	unsigned long ewmh_hint_desktop;
+	Bool fullscreen_monitors_set; /* has seen _NET_WM_FULLSCREEN_MONITORS */
 
 	/* For the purposes of restoring attributes before/after a window goes
 	 * into fullscreen.

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -286,6 +286,11 @@ Bool FScreenIsEnabled(void)
 	return (!is_xinerama_enabled || num_screens == 0) ? False : True;
 }
 
+int FScreenNumberOfScreens(void)
+{
+	return is_xinerama_enabled ? num_screens : 0;
+}
+
 Bool FScreenIsSLSEnabled(void)
 {
 	return is_sls_enabled;

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -47,6 +47,7 @@ void FScreenConfigureModule(char *args);
 const char* FScreenGetConfiguration(void); /* For use by fvwm */
 void FScreenSetDefaultModuleScreen(char *scr_spec);
 void FScreenDisableRandR(void);
+int FScreenNumberOfScreens(void);
 
 void FScreenSetPrimaryScreen(int scr);
 


### PR DESCRIPTION
This is an implementation of the _NET_WM_FULLSCREEN_MONITORS EWMH feature.

This feature is used by VirtualBox and VMware Workstation to decide about the host's monitor set.

Without it, VMware Workstation doesn't allow using multiple monitors for the guest.

Tested on both, FreeBSD and Linux.