### PR TITLE
Update icons.c

### DIFF
--- a/fvwm/icons.c
+++ b/fvwm/icons.c
@@ -787,7 +787,7 @@ void CreateIconWindow(FvwmWindow *fw, int def_x, int def_y)
 			GetUnusedModifiers(), Scr.FvwmCursors[CRS_DEFAULT],
 			True);
 		xwc.sibling = FW_W_FRAME(fw);
-		xwc.stack_mode = Below;
+		xwc.stack_mode = Above;
 		XConfigureWindow(
 			dpy, FW_W_ICON_TITLE(fw), CWSibling|CWStackMode, &xwc);
 	}


### PR DESCRIPTION
Sibling stacking set to prevent lower-right shadows from shadowing icon titles when using a compositor.  Lower right shadows are consistent with current default Fvwm menus, so this fix provides a unified and correct look for the defacto standard case.