### PR TITLE
Avoid absolute symlinks

### DIFF
--- a/default-config/Makefile.am
+++ b/default-config/Makefile.am
@@ -17,9 +17,9 @@ EXTRA_DIST  = images \
 
 install-data-hook:
 	cp -r $(srcdir)/images $(inst_location)
-	ln -sf $(inst_location)/FvwmScript-DateTime $(inst_location)/..
-	ln -sf $(inst_location)/FvwmScript-ConfirmQuit $(inst_location)/..
-	ln -sf $(inst_location)/FvwmScript-ConfirmCopyConfig $(inst_location)/..
+	ln -sf default-config/FvwmScript-DateTime $(inst_location)/..
+	ln -sf default-config/FvwmScript-ConfirmQuit $(inst_location)/..
+	ln -sf default-config/FvwmScript-ConfirmCopyConfig $(inst_location)/..
 
 uninstall-hook:
 	rm -fr $(DESTDIR)/$(configdir)


### PR DESCRIPTION
Using absolute symlinks breaks build of rootfs for a target different
than host, because the root is different between build time
and runtime. This is the case with pyro release of Yocto.

Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.co.uk>
Signed-off-by: Fabien Lahoudere <fabien.lahoudere@collabora.com>