### PR TITLE
Drop mg_DEFINE_IF_NOT macro

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -302,40 +302,6 @@ else
 fi])
 
 
-dnl Defines a boolean variable for config.h depending on a condition.
-dnl
-dnl Usage:
-dnl mg_DEFINE_IF_NOT(c-code, cpp-if-cond, var-name, extra-flags, var-comment)
-dnl
-dnl c-code       the first code part inside main()
-dnl cpp-if-cond  boolean preprocessor condition
-dnl var-name     this variable will be defined if the given condition is false
-dnl extra-flags  (optional) extra flags for compiling, typically more -I glags
-dnl
-dnl Example:
-dnl mg_DEFINE_IF_NOT([#include <features.h>], [defined __USE_BSD], [NON_BSD])
-dnl
-AC_DEFUN([mg_DEFINE_IF_NOT], [
-mg_save_CPPFLAGS="$CPPFLAGS"
-ifelse($4, , , CPPFLAGS="$CPPFLAGS [$4]")
-
-AH_TEMPLATE([$3],[$5])
-AC_TRY_RUN([
-#include <stdio.h>
-int main(int c, char **v) {
-$1
-#if $2
-  return 0;
-#else
-  return 1;
-#endif
-}
-], [:], [AC_DEFINE($3)])
-
-CPPFLAGS="$mg_save_CPPFLAGS"
-])
-
-
 # Check for gdk-imlib
 AC_DEFUN([AM_PATH_GDK_IMLIB],
 [dnl

--- a/configure.ac
+++ b/configure.ac
@@ -1421,29 +1421,6 @@ else
   problem_gdkimlib=": Failed on gdk-imlib, see config.log"
 fi
 
-# Define some compatibility macros needed for config.h.
-mg_DEFINE_IF_NOT([#include <X11/keysym.h>],
-  [defined XK_Page_Up && defined XK_Page_Down],
-  [COMPAT_OLD_KEYSYMDEF], [$X_CFLAGS],
-  [Old AIX systems (3.2.5) don't define some common keysyms.])
-AH_VERBATIM([_COMPAT_OLD_KEYSYMDEF],
-[#ifdef COMPAT_OLD_KEYSYMDEF
-#  define XK_Page_Up   XK_Prior
-#  define XK_Page_Down XK_Next
-#endif])
-
-if test x"$with_stroke" = xyes; then
-  mg_DEFINE_IF_NOT([#include <stroke.h>],
-    [defined STROKE_MAX_SEQUENCE],
-    [COMPAT_OLD_LIBSTROKE], [$stroke_CFLAGS],
-    [Old libstroke <= 0.4 does not use STROKE_ prefix for constants.])
-fi
-AH_VERBATIM([_COMPAT_OLD_LIBSTROKE],
-[#ifdef COMPAT_OLD_LIBSTROKE
-/* currently we only use one constant */
-#  define STROKE_MAX_SEQUENCE MAX_SEQUENCE
-#endif])
-
 
 # Allow building with dmalloc.  Do this last to avoid screwing up any
 # other checks above.


### PR DESCRIPTION
Building fvwm with Yocto, we get the following error.

configure: error: in `/home/.../poky/build/tmp/work/cortexa8hf-neon-...-linux-gnueabi/fvwm/2.6.7+gitAUTOINC+597a4e296d-r0/build':
| configure: error: cannot run test program while cross compiling
| See `config.log' for more details
| ERROR: configure failed

The error is due to mg_DEFINE_IF_NOT that use AC_TRY_RUN which is not
possible when cross compiling.

We drop the macro and occurencies.

Signed-off-by: Fabien Lahoudere <fabien.lahoudere@collabora.com>