### PR TITLE
Update ewmh.c

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1522,15 +1522,6 @@ int ewmh_HandleToolBar(
 {
 	fw->ewmh_window_type = EWMH_WINDOW_TYPE_TOOLBAR_ID;
 
-	/* this ok for KDE 2 (and 3??) but I do not think that a toolbar
-	   should be sticky */
-	S_SET_IS_STICKY_ACROSS_PAGES(SCF(*style), 1);
-	S_SET_IS_STICKY_ACROSS_PAGES(SCM(*style), 1);
-	S_SET_IS_STICKY_ACROSS_PAGES(SCC(*style), 1);
-	S_SET_IS_STICKY_ACROSS_DESKS(SCF(*style), 1);
-	S_SET_IS_STICKY_ACROSS_DESKS(SCM(*style), 1);
-	S_SET_IS_STICKY_ACROSS_DESKS(SCC(*style), 1);
-
 	S_SET_DO_WINDOW_LIST_SKIP(SCF(*style), 1);
 	S_SET_DO_WINDOW_LIST_SKIP(SCM(*style), 1);
 	S_SET_DO_WINDOW_LIST_SKIP(SCC(*style), 1);


### PR DESCRIPTION
I was using Libreoffice, and I noticed that in fvwm, the Libreoffice table toolbar is sticky across pages and desktops. I don't think it is supposed to be sticky. It doesn't make sense for a toolbar to be sticky, and it isn't sticky in other window managers. Actually, all toolbars are sticky in fvwm.

I looked at the source code and found that someone had left a comment saying they didn't think toolbars should be sticky, but apparently they made them sticky anyway.

I wrote this patch that makes toolbars be not sticky.

The comment also mentions something about being "ok for KDE". I tried out this patch with KDE + fvwm, and I didn't notice anything amiss.

It would be great if this could be part of the official program. This issue has been bugging me for a while. Thanks.

I attached a zip file containing a video of the bug.
[bug.zip](https://github.com/fvwmorg/fvwm/files/2107221/bug.zip)

