### PR TITLE
windows cannot be moved to desktop/workspace 0

### DIFF
--- a/fvwm/ewmh_events.c
+++ b/fvwm/ewmh_events.c
@@ -290,7 +290,7 @@ int ewmh_WMDesktop(
 			execute_function_override_window(
 				NULL, NULL, "Stick on", 0, fw);
 		}
-		else if (d > 0)
+		else if (d >= 0)
 		{
 			if (IS_STICKY_ACROSS_PAGES(fw) ||
 			    IS_STICKY_ACROSS_DESKS(fw))


### PR DESCRIPTION
windows cannot be moved to desktop/workspace 0 when using facilities of thirdparty libraries such as libwnck