### PR TITLE
Division by zero in FvwmPager when desk_h==0 or desk_w==0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ Changes in stable release 2.6.9 (UNRELEASED)
 * Bug fixes:
 
   - Fix handling of configure's --enable-mandoc/--enable-htmldoc
+  - Fix crash in FvwmPager when desk height or width is 0
 
 * New fvwm features:
 

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -1934,8 +1934,14 @@ void SwitchToDeskAndPage(int Desk, XEvent *Event)
   {
     int vx, vy;
     /* patch to let mouse button 3 change desks and do not cling to a page */
-    vx = Event->xbutton.x * Scr.VWidth / (desk_w * Scr.MyDisplayWidth);
-    vy = Event->xbutton.y * Scr.VHeight / (desk_h * Scr.MyDisplayHeight);
+    if (desk_w == 0)
+      vx = 0;
+    else
+      vx = Event->xbutton.x * Scr.VWidth / (desk_w * Scr.MyDisplayWidth);
+    if (desk_h == 0)
+      vy = 0;
+    else
+      vy = Event->xbutton.y * Scr.VHeight / (desk_h * Scr.MyDisplayHeight);
     Scr.Vx = vx * Scr.MyDisplayWidth;
     Scr.Vy = vy * Scr.MyDisplayHeight;
     sprintf(command, "GotoDeskAndPage %d %d %d", Desk + desk1, vx, vy);
@@ -1944,8 +1950,15 @@ void SwitchToDeskAndPage(int Desk, XEvent *Event)
   }
   else
   {
-    int x = Event->xbutton.x * Scr.VWidth / (desk_w * Scr.MyDisplayWidth);
-    int y = Event->xbutton.y * Scr.VHeight / (desk_h * Scr.MyDisplayHeight);
+    int x, y;
+    if (desk_w == 0)
+      x = 0;
+    else
+      x = Event->xbutton.x * Scr.VWidth / (desk_w * Scr.MyDisplayWidth);
+    if (desk_h == 0)
+      y = 0;
+    else
+      y = Event->xbutton.y * Scr.VHeight / (desk_h * Scr.MyDisplayHeight);
 
     /* Fix for buggy XFree86 servers that report button release events
      * incorrectly when moving fast. Not perfect, but should at least prevent


### PR DESCRIPTION
gdb -c FvwmPager.core /usr/local/lib/X11/fvwm2/2.6.9/FvwmPager
GNU gdb (GDB) 8.3
...
Reading symbols from /usr/local/lib/X11/fvwm2/2.6.9/FvwmPager...
[New process 1]
Core was generated by `FvwmPager'.
Program terminated with signal SIGFPE, Arithmetic exception.
    at x_pager.c:1938
1938        vy = Event->xbutton.y * Scr.VHeight / (desk_h * Scr.MyDisplayHeight);

(gdb) p desk_h
$1 = 0

(gdb) p  Event->xbutton.y
$31 = -1
(gdb) p Scr.VHeight
$32 = 1080
(gdb) p desk_h
$33 = 0
(gdb) p Scr.MyDisplayHeight
$34 = 1080

(gdb) p Event->xbutton.x
$38 = 33
(gdb) p Scr.VWidth
$39 = 1920
(gdb) p desk_w
$40 = 64
(gdb) p Scr.MyDisplayWidth
$41 = 1920