### PR TITLE
Fix formatting error in manpages.

### DIFF
--- a/bin/fvwm-menu-desktop.1.in
+++ b/bin/fvwm-menu-desktop.1.in
@@ -123,7 +123,7 @@ are included in the top level menu. \fINAME\fR can be one of \fIregenerate\fR,
 
 .IP "\fB\-\-regen\-cmd\fR \fICMD\fR "
 This option sets the fvwm command \fICMD\fR that is run when the menu item
-\'Regenerate' is selected. The default is "PipeRead `fvwm-menu-desktop`".
+\&'Regenerate' is selected. The default is "PipeRead `fvwm-menu-desktop`".
 
 .IP "\fB\-\-term\-cmd\fR \fICMD\fR "
 This option sets the terminal emulator command \fICMD\fR that is used to
@@ -198,11 +198,11 @@ use this option to specify a different folder.
 
 .IP "\fB\-\-app\-icon\fR \fINAME\fR"
 Sets the default application icon if no others are found. Default is
-\'gnome-applications'.
+\&'gnome-applications'.
 
 .IP "\fB\-\-dir\-icon\fR \fINAME\fR"
 Sets the default directory icon if no others are found. Default is
-\'gnome-fs-directory'.
+\&'gnome-fs-directory'.
 
 .SH USAGE
 \fBfvwm-menu-desktop\fR outputs XDG .menu files in the syntax of fvwm

--- a/modules/FvwmButtons/FvwmButtons.1.in
+++ b/modules/FvwmButtons/FvwmButtons.1.in
@@ -711,7 +711,7 @@ like this:
 .sp
 .fi
 Any single character can be quoted with a preceding
-backslash '\\'.
+backslash '\(rs'.
 .RE
 .\" End relative indent
 .SH CREATING PANELS

--- a/modules/FvwmCommand/FvwmCommand.1.in
+++ b/modules/FvwmCommand/FvwmCommand.1.in
@@ -106,7 +106,7 @@ FvwmCommand -i 0 foobar
 will return,
 .EX
 [fvwm][executeModule]: <<ERROR>> No such module
-\'foobar\' in ModulePath '/usr/lib/X11/fvwm'
+\&'foobar' in ModulePath '/usr/lib/X11/fvwm'
 .EE
 
 Note that Fvwm doesn't return any error messages in
@@ -239,7 +239,7 @@ The below will iconify new windows when opened.
 Fvwm -mi3 | perl -ne '
 $|=1;
 print "windowid $1 iconify\\n" if /^(0x\\S+) add/;
-\' > ~/\.FvwmCommandC
+\&' > ~/\.FvwmCommandC
 .EE
 .IP "\fI-r\fR"
 Waits for a reply before it exits.

--- a/modules/FvwmConsole/FvwmConsoleC.pl.1.in
+++ b/modules/FvwmConsole/FvwmConsoleC.pl.1.in
@@ -165,7 +165,7 @@ string. Example:
 Typing 'bigx<return>' in FvwmConsole will launch xterm. '^' denotes
 the beginning of line in
 .B regular expression.
-\'pl\' in the middle
+\&'pl' in the middle
 of the command will not be replaced. Although the format looks different,
 it takes Perl regular expression.
 It just uses single or double quote as the delimiter.


### PR DESCRIPTION
Groff treats \' as an acute accent and not an escaped quote. Fixed
a few issues of this so the proper character is produced.