### PR TITLE
Cleanup some minor issues with build tools.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,3 +38,6 @@ distcheck2: distcheck
 	fi
 
 distclean2: distclean
+
+uninstall-hook:
+	-rmdir @FVWM_DATADIR@

--- a/configure.ac
+++ b/configure.ac
@@ -374,8 +374,8 @@ problem_mandoc=""
 AC_CHECK_PROG(XSLTPROC, xsltproc, xsltproc, "")
 
 AC_ARG_ENABLE(mandoc,
-  AS_HELP_STRING([--disable-mandoc],
-    [disable generation of man pages]),
+  AS_HELP_STRING([--enable-mandoc],
+    [enable generation of man pages]),
   [ if test x"$enableval" = xyes; then
 		with_mandoc="yes, check"
 	else
@@ -1622,9 +1622,6 @@ AC_SUBST(with_xpm)
 dnl with autoconf <2.60 this is needed
 AC_SUBST(datarootdir)
 AC_SUBST(docdir)
-
-LOCAL_BUGADDR=${FVWM_BUGADDR-${USER-${LOGNAME-`whoami`}}}
-AC_SUBST(LOCAL_BUGADDR)
 
 AC_OUTPUT(
 	Makefile

--- a/default-config/Makefile.am
+++ b/default-config/Makefile.am
@@ -1,7 +1,7 @@
 ## Process this file with automake to create Makefile.in
 
 configdir = @FVWM_DATADIR@/default-config
-inst_location = $(DESTDIR)@FVWM_DATADIR@/default-config
+inst_location = $(DESTDIR)@FVWM_DATADIR@
 config_DATA = config \
 	      .stalonetrayrc \
 	      FvwmScript-DateTime \
@@ -16,10 +16,13 @@ EXTRA_DIST  = images \
 	      FvwmScript-ConfirmCopyConfig
 
 install-data-hook:
-	cp -r $(srcdir)/images $(inst_location)
-	ln -sf default-config/FvwmScript-DateTime $(inst_location)/..
-	ln -sf default-config/FvwmScript-ConfirmQuit $(inst_location)/..
-	ln -sf default-config/FvwmScript-ConfirmCopyConfig $(inst_location)/..
+	cp -r $(srcdir)/images $(inst_location)/default-config
+	ln -sf default-config/FvwmScript-DateTime $(inst_location)
+	ln -sf default-config/FvwmScript-ConfirmQuit $(inst_location)
+	ln -sf default-config/FvwmScript-ConfirmCopyConfig $(inst_location)
 
 uninstall-hook:
 	rm -fr $(DESTDIR)/$(configdir)
+	rm -f $(inst_location)/FvwmScript-DateTime
+	rm -f $(inst_location)/FvwmScript-ConfirmQuit
+	rm -f $(inst_location)/FvwmScript-ConfirmCopyConfig

--- a/modules/FvwmCommand/FvwmCommand.1.in
+++ b/modules/FvwmCommand/FvwmCommand.1.in
@@ -281,33 +281,6 @@ FvwmCommand exits if no information or error is returned in a fixed amount of
 time period unless option -m is used.
 The default is 500 ms. This option overrides this default value.
 
-.SH WRAPPER
-.sp
-.sp
-FvwmCommand.sh has bourne shell function definitions
-to keep the syntax similar to fvwm configuration file.
-This file is to be sourced:
-.EX
-\&. FvwmCommand.sh
-.br
-DesktopSize 5x5
-.EE
-.br
-FvwmCommand.pm is for perl in order
-to keep the syntax similar to fvwm configuration file.
-Commas can be used to separate fvwm commands' arguments.
-.EX
-use FvwmCommand;
-if( $ARGV[0] eq 'home' ) {
-    Desk 0,0; GotoPage '1 1';
-}elsif( $ARGV[0] eq 'jump' ) {
-    Desk "0 2"; GotoPage 0, 1;
-}
-.EE
-Although arguments in FvwmCommand are not case sensitive as fvwm,
-the functions defined in FvwmCommand.sh and FvwmCommand.pl are case sensitive.
-
-
 .SH ERRORS
 If the following error message show up, it is most likely that FvwmCommandS
 is not running.

--- a/modules/FvwmCommand/Makefile.am
+++ b/modules/FvwmCommand/Makefile.am
@@ -6,29 +6,14 @@ SUBDIRS = scripts
 
 bin_PROGRAMS = FvwmCommand
 moduledir = @FVWM_MODULEDIR@
-module_DATA = FvwmCommand.sh FvwmCommand.pm
 
 FvwmCommand_SOURCES = FvwmCommand.c FvwmCommand.h fifos.c
-
-FvwmCommand.sh: findcmd.pl $(top_srcdir)/fvwm/functable.c
-	if test -n "$(PERL)" -a -x "$(PERL)"; then \
-		$(PERL) $(srcdir)/findcmd.pl $(bindir) -sh \
-		< $(top_srcdir)/fvwm/functable.c > $@; \
-	else echo '# Did not find perl during fvwm install' > $@; fi
-
-FvwmCommand.pm: findcmd.pl $(top_srcdir)/fvwm/functable.c
-	if test -n "$(PERL)" -a -x "$(PERL)"; then \
-		$(PERL) $(srcdir)/findcmd.pl $(bindir) \
-		< $(top_srcdir)/fvwm/functable.c > $@; \
-	else echo '# Did not find perl during fvwm install' > $@; fi
-
-CLEANFILES = FvwmCommand.sh FvwmCommand.pm
 
 FvwmCommand_DEPENDENCIES = $(top_builddir)/libs/libfvwm.a
 
 man_MANS = FvwmCommand.1
 
-EXTRA_DIST = $(man_MANS) findcmd.pl
+EXTRA_DIST = $(man_MANS)
 
 LDADD = -L$(top_builddir)/libs -lfvwm
 

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -5,3 +5,7 @@ SUBDIRS = \
 	FvwmCommandS FvwmConsole FvwmCpp FvwmEvent FvwmForm \
 	FvwmIconMan FvwmIdent FvwmM4 FvwmPager \
 	FvwmPerl FvwmProxy FvwmRearrange FvwmScript
+
+uninstall-hook:
+	-rmdir @FVWM_MODULEDIR@
+	-rmdir ${pkglibexecdir}


### PR DESCRIPTION
  * Update ./configure --help to correctly state that --enable-mandoc is needed to build man pages.
  * Update make uninstall to remove the directories and links created during the install.
  * Remove *_BUGADDR from configure.ac.
  * Don't build broken FvwmCommand.{pm,sh} scripts.