### PR TITLE
Apply Debian Patches

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -542,37 +542,6 @@ c = locale_charset ();
 ])
 
 #-----------------------------------------------------------------------------
-# pkg-config
-
-dnl
-dnl
-AC_DEFUN([AM_CHECK_PKG_CONFIG],
-[dnl
-dnl Get the cflags and libraries from the freetype-config script
-dnl
-AC_ARG_WITH(pkgconfig-prefix,
-AS_HELP_STRING([--with-pkgconfig-prefix=PFX],[prefix where pkg-config is installed]),
-            pkgconfig_config_prefix="$withval", pkgconfig_config_prefix="")
-AC_ARG_WITH(pkgconfig-exec-prefix,
-AS_HELP_STRING([--with-pkgconfig-exec-prefix=PFX],[exec prefix where pkg-config is installed]),
-            pkgconfig_config_exec_prefix="$withval",pkgconfig_config_exec_prefix="")
-
-if test x$pkgconfig_config_exec_prefix != x ; then
-  pkgconfig_config_args="$pkgconfig_config_args --exec-prefix=$pkgconfig_config_exec_prefix"
-  if test x${PKG_CONFIG+set} != xset ; then
-    PKG_CONFIG=$pkgconfig_config_exec_prefix/bin/pkg-config
-  fi
-fi
-if test x$pkgconfig_config_prefix != x ; then
-  pkgconfig_config_args="$pkgconfig_config_args --prefix=$pkgconfig_config_prefix"
-  if test x${PKG_CONFIG+set} != xset ; then
-    PKG_CONFIG=$pkgconfig_config_prefix/bin/pkg-config
-  fi
-fi
-AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-])
-
-#-----------------------------------------------------------------------------
 # Configure paths for fontconfig
 # Marcelo Magallon 2001-10-26, based on gtk.m4 by Owen Taylor
 # modified by olicha for fontconfig

--- a/bin/fvwm-bug.in
+++ b/bin/fvwm-bug.in
@@ -85,7 +85,7 @@ trap 'rm -f $TEMP $TEMP.x' 0
 
 # Who is mail to?
 if test x"$address" = x; then
-	LOCAL=@LOCAL_BUGADDR@
+	LOCAL=
 	WORKERS=fvwm-workers@fvwm.org
 
 	if test "$LOCAL"; then

--- a/bin/fvwm-menu-directory.in
+++ b/bin/fvwm-menu-directory.in
@@ -200,7 +200,7 @@ my $sort_sub =
 @files = reverse @files if $order < 0;
 
 # dump all menu items and start adding new items
-my $menu_name  = &escape_fvwm_name($name);
+my $menu_name  = &escape_file_name($name);
 my $menu_name2 = &escape_menu_name($name);
 print qq(DestroyMenu recreate "$menu_name"\nAddToMenu "$menu_name2"\n);
 

--- a/configure.ac
+++ b/configure.ac
@@ -1274,7 +1274,7 @@ AC_SUBST(FVWMTASKBAR_DOMAIN)
 AC_SUBST(FVWMSCRIPT_DOMAIN)
 AC_SUBST(ALL_DOMAINS)
 
-LOCALEDIR='${datadir}'"/locale"
+LOCALEDIR="$FVWM_DATADIR/locale"
 with_gettext="yes"
 problem_gettext=""
 

--- a/configure.ac
+++ b/configure.ac
@@ -281,7 +281,7 @@ esac
 # unfortunately, we need pkg-config for the detection of certain libs:
 # - version of fontconfig without fontconfig-config
 # - version of fribidi without fribidi-config
-AM_CHECK_PKG_CONFIG
+PKG_PROG_PKG_CONFIG
 
 
 # Building man pages & HTML documentation (from XML source).
@@ -879,7 +879,7 @@ AC_ARG_ENABLE(rsvg,
 )
 if test ! x"$with_rsvg" = xno; then
    with_rsvg=no
-   if test ! x"$PKG_CONFIG" = xno ; then
+   if test ! x"$PKG_CONFIG" = x ; then
       AC_MSG_CHECKING(for librsvg - version >= $rsvg_min_version)
       if $PKG_CONFIG --exists librsvg-2.0 ; then
          if $PKG_CONFIG --exists "librsvg-2.0 >= $rsvg_min_version" ; then
@@ -1163,7 +1163,7 @@ if test ! x"$with_bidi" = xno; then
     AS_HELP_STRING([--with-fribidi-bindir=DIR],
       [directory of fribidi-config if not in PATH]),
     FRIBIDI_BINDIR="$withval", FRIBIDI_BINDIR=".")
-  if test ! x"$PKG_CONFIG" = xno && $PKG_CONFIG --exists "fribidi >= $fribidi_min_version"; then
+  if test ! x"$PKG_CONFIG" = x && $PKG_CONFIG --exists "fribidi >= $fribidi_min_version"; then
     FRIBIDI_CONFIG="$PKG_CONFIG fribidi"
   else
     AC_PATH_PROG(FRIBIDI_CONFIG, fribidi-config,, [$FRIBIDI_BINDIR:$PATH])

--- a/default-config/config
+++ b/default-config/config
@@ -55,13 +55,18 @@ InfoStoreAdd terminal xterm
 # actions that are run after a restart.
 DestroyFunc StartFunction
 AddToFunc   StartFunction
-+ I Test (Init, f $[FVWM_USERDIR]/.BGdefault) \
-    Exec exec fvwm-root $[FVWM_USERDIR]/.BGdefault
-+ I TestRc (NoMatch) Exec exec fvwm-root \
-    $[FVWM_DATADIR]/default-config/images/background/bg1.png
++ I Test (Init) InitBackground
 + I Test (Init) Module FvwmBanner
 + I Module FvwmButtons RightPanel
 + I Module FvwmEvent EventNewDesk
+
+# Function to set background when fvwm starts
+DestroyFunc InitBackground
+AddToFunc InitBackground
++ I Test (f $[FVWM_USERDIR]/.BGdefault) \
+    Exec exec fvwm-root $[FVWM_USERDIR]/.BGdefault
++ I TestRc (NoMatch) Exec exec fvwm-root \
+    $[FVWM_DATADIR]/default-config/images/background/bg1.png
 
 # Mouse Bindings Functions
 DestroyFunc RaiseMoveX
@@ -654,3 +659,11 @@ DestroyModuleConfig EventNewDesk:*
 # This sets the default colorsets.
 *FvwmFormDefault: Colorset 10
 *FvwmFormDefault: ItemColorset 13
+
+# Local configuration file. For use with the default-config.
+#
+# If $FVWMUSER_DIR/local.config ($HOME/.fvwm/local.config by default)
+# exists, then read it. This allows changes to default-config settings
+# without needing a full copy of the default-config. This will also allow
+# default-config changes to get used after upgrades (if applicable).
+Test (f $[FVWM_USERDIR]/local.config) Read $[FVWM_USERDIR]/local.config

--- a/doc/commands/ClickTime.xml
+++ b/doc/commands/ClickTime.xml
@@ -26,4 +26,6 @@ is 150 milliseconds.  Omitting the delay value resets the
 <emphasis remap='B'>ClickTime</emphasis>
 to the default.</para>
 
+<para><emphasis remap='B'>ClickTime</emphasis> also specifies the delay
+between two clicks to be interpreted as a double-click.</para>
 </section>

--- a/libs/defaults.h
+++ b/libs/defaults.h
@@ -25,7 +25,7 @@
 /* The "extended" buttons do not provide the full functionality because X has
  * no bit mask value for them.  Things like dragging windows don't work with
  * them. */
-#define NUMBER_OF_EXTENDED_MOUSE_BUTTONS   9
+#define NUMBER_OF_EXTENDED_MOUSE_BUTTONS   15
 #if NUMBER_OF_EXTENDED_MOUSE_BUTTONS > 31
 #error No more than 31 mouse buttons can be supported on 32 bit platforms
 #endif

--- a/modules/FvwmIconMan/xmanager.c
+++ b/modules/FvwmIconMan/xmanager.c
@@ -438,6 +438,16 @@ static void resize_window(WinManager *man)
     }
     MyXUngrabServer(theDisplay);
   }
+
+  // Wait until the window has resised to fix the HINTS.
+  // counter is used to break an infinte loop.
+  XWindowAttributes attribs;
+  int counter = 20000;
+  while ( counter && (attribs.width != man->geometry.width ||
+          attribs.height != man->geometry.height)) {
+    XGetWindowAttributes(theDisplay, man->theWindow, &attribs);
+    counter--;
+  }
   fix_manager_size(man, man->geometry.width, man->geometry.height);
 }
 


### PR DESCRIPTION
Add patches from the Debian package of fvwm.

+ Increase number of extended mouse buttons.
+ Use upstream `PKG_PROG_PKG_CONFIG`.
+ Reproducible Builds.
+ Fix `FvwmIconMan` triggering size hint warnings.
+ Add double click time info to `ClickTime` in manpage.
+ `fvwm-menu-directory`: escape file name correctly.
+ Move Locales to `$FVWM_DATADIR`
+ default-config bugfix and local configuration file.