### PR TITLE
Fixes for C99 compatibility

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -30,7 +30,7 @@ if test "$ac_cv_func_select" = yes; then
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif],
-[extern select ($ac_cv_type_fd_set_size_t,
+[extern int select ($ac_cv_type_fd_set_size_t,
  $ac_cv_type_fd_set *,	$ac_cv_type_fd_set *, $ac_cv_type_fd_set *,
  $ac_type_timeval *);],
 [ac_found=yes ; break 3],ac_found=no)

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1154,6 +1154,9 @@ AC_DEFUN([AM_SAFETY_CHECK_MKSTEMP],[
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 int main(void)
 {
   char template[128];

--- a/configure.ac
+++ b/configure.ac
@@ -220,9 +220,8 @@ AC_MINIX
 
 # catch -Werror and similar options when running configure
 AC_TRY_COMPILE([#include <stdio.h>],
-[int i; int *p; char *c;
-  switch (*p = p = *c) { case 0: printf("%Q", c, p); }
-  *c = &i; c = p;
+[int unused; int *p; char *c;
+  printf("%Q", c, p);
   while (1 || (unsigned int)3 >= 0 || ((int)-1) == ((unsigned int)1));
 ], , AC_MSG_ERROR("
 configure is not able to compile programs with warnings.  Please

--- a/configure.ac
+++ b/configure.ac
@@ -220,7 +220,7 @@ AC_MINIX
 
 # catch -Werror and similar options when running configure
 AC_TRY_COMPILE([#include <stdio.h>],
-[int i; static j; int *p; char *c;
+[int i; int *p; char *c;
   switch (*p = p = *c) { case 0: printf("%Q", c, p); }
   *c = &i; c = p;
   while (1 || (unsigned int)3 >= 0 || ((int)-1) == ((unsigned int)1));


### PR DESCRIPTION
This will allow building with compilers that diagnose some C99 constraint violations as errors instead of warnings.