### PR TITLE
Use last event time when calling XSetInputFocus

### DIFF
--- a/fvwm/focus.c
+++ b/fvwm/focus.c
@@ -80,7 +80,7 @@ static FvwmWindow *LastScreenFocus = NULL;
 void _focus_set(Window w, FvwmWindow *fw)
 {
 	Scr.focus_in_requested_window = fw;
-	XSetInputFocus(dpy, w, RevertToParent, CurrentTime);
+	XSetInputFocus(dpy, w, RevertToParent, fev_get_evtime());
 
 	return;
 }
@@ -88,7 +88,7 @@ void _focus_set(Window w, FvwmWindow *fw)
 void _focus_reset(void)
 {
 	Scr.focus_in_requested_window = NULL;
-	XSetInputFocus(dpy, PointerRoot, RevertToPointerRoot, CurrentTime);
+	XSetInputFocus(dpy, PointerRoot, RevertToPointerRoot, fev_get_evtime());
 
 	return;
 }


### PR DESCRIPTION
  This fixes a race condition when WM_TAKE_FOCUS message is sent to
  client windows, with the last event time as time parameter. The
  client might react to the WM_TAKE_FOCUS message with a XSetInputFocus
  call, and is expected to pass the message time as time parameter.

  As fvwm concurrently calls XSetInputFocus with CurrentTime, it causes
  a race condition and sometimes the X server gives focus to fvwm
  window, stealing the focus from the client window.