### PR TITLE
configure: drop check for -Werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,17 +218,6 @@ fi
 AC_ISC_POSIX
 AC_MINIX
 
-# catch -Werror and similar options when running configure
-AC_TRY_COMPILE([#include <stdio.h>],
-[int i; static j; int *p; char *c;
-  switch (*p = p = *c) { case 0: printf("%Q", c, p); }
-  *c = &i; c = p;
-  while (1 || (unsigned int)3 >= 0 || ((int)-1) == ((unsigned int)1));
-], , AC_MSG_ERROR("
-configure is not able to compile programs with warnings.  Please
-remove all offending options like -Werror from the CFLAGS and
-CPPFLAGS variables and run configure again."))
-
 # check size of some types
 ac_save_CFLAGS="$CFLAGS"
 CFLAGS="$CFLAGS $X_CFLAGS"


### PR DESCRIPTION
This made sense with much older compilers, but now that clag and gcc are adding errors all the time, this check is redundant.

This fixes building with gcc-14 and Debian bug 1074974: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1074974